### PR TITLE
feat: replace deprecated typography classes

### DIFF
--- a/lib/rules/no-deprecated-classes.js
+++ b/lib/rules/no-deprecated-classes.js
@@ -31,18 +31,19 @@ const replacements = new Map([
 ])
 
 if (getInstalledVuetifyVersion() >= '2.3.0') {
-  replacements.set('display-4', 'text-h1')
-  replacements.set('display-3', 'text-h2')
-  replacements.set('display-2', 'text-h3')
-  replacements.set('display-1', 'text-h4')
-  replacements.set('headline', 'text-h5')
-  replacements.set('title', 'text-h6')
-  replacements.set('subtitle-1', 'text-subtitle-1')
-  replacements.set('subtitle-2', 'text-subtitle-2')
-  replacements.set('body-1', 'text-body-1')
-  replacements.set('body-2', 'text-body-2')
-  replacements.set('caption', 'text-caption')
-  replacements.set('overline', 'text-overline')
+  replacements
+    .set('display-4', 'text-h1')
+    .set('display-3', 'text-h2')
+    .set('display-2', 'text-h3')
+    .set('display-1', 'text-h4')
+    .set('headline', 'text-h5')
+    .set('title', 'text-h6')
+    .set('subtitle-1', 'text-subtitle-1')
+    .set('subtitle-2', 'text-subtitle-2')
+    .set('body-1', 'text-body-1')
+    .set('body-2', 'text-body-2')
+    .set('caption', 'text-caption')
+    .set('overline', 'text-overline')
 }
 
 // These components treat attributes like classes

--- a/lib/rules/no-deprecated-classes.js
+++ b/lib/rules/no-deprecated-classes.js
@@ -2,6 +2,7 @@
 
 const { classify, getAttributes } = require('../util/helpers')
 const { removeAttr } = require('../util/fixers')
+const { getInstalledVuetifyVersion } = require('../util/get-installed-vuetify-version')
 
 // const spacers = {
 //   0: 0,
@@ -28,6 +29,21 @@ const replacements = new Map([
   // TODO: only run fixer once
   // [/([mp][axytblr])-(\d)/, (type, n) => `${type}-${spacers[n]}`]
 ])
+
+if (getInstalledVuetifyVersion() >= '2.3.0') {
+  replacements.set('display-4', 'text-h1')
+  replacements.set('display-3', 'text-h2')
+  replacements.set('display-2', 'text-h3')
+  replacements.set('display-1', 'text-h4')
+  replacements.set('headline', 'text-h5')
+  replacements.set('title', 'text-h6')
+  replacements.set('subtitle-1', 'text-subtitle-1')
+  replacements.set('subtitle-2', 'text-subtitle-2')
+  replacements.set('body-1', 'text-body-1')
+  replacements.set('body-2', 'text-body-2')
+  replacements.set('caption', 'text-caption')
+  replacements.set('overline', 'text-overline')
+}
 
 // These components treat attributes like classes
 const gridComponents = ['VContainer', 'VLayout', 'VFlex', 'VSpacer']

--- a/lib/util/get-installed-vuetify-version.js
+++ b/lib/util/get-installed-vuetify-version.js
@@ -1,0 +1,13 @@
+const { createRequire } = require('module')
+const path = require('path')
+
+function getInstalledVuetifyVersion () {
+  try {
+    const installedVuetify = createRequire(path.resolve(process.cwd(), 'package.json'))('vuetify/package.json')
+    return installedVuetify.version
+  } catch (e) {}
+}
+
+module.exports = {
+  getInstalledVuetifyVersion
+}

--- a/lib/util/get-installed-vuetify-version.js
+++ b/lib/util/get-installed-vuetify-version.js
@@ -1,5 +1,20 @@
-const { createRequire } = require('module')
+const Module = require('module')
 const path = require('path')
+
+// https://github.com/benmosher/eslint-plugin-import/pull/1591
+// https://github.com/benmosher/eslint-plugin-import/pull/1602
+// Polyfill Node's `Module.createRequireFromPath` if not present (added in Node v10.12.0)
+// Use `Module.createRequire` if available (added in Node v12.2.0)
+// eslint-disable-next-line node/no-deprecated-api
+const createRequire = Module.createRequire || Module.createRequireFromPath || function (filename) {
+  const mod = new Module(filename, null)
+  mod.filename = filename
+  mod.paths = Module._nodeModulePaths(path.dirname(filename))
+
+  mod._compile(`module.exports = require;`, filename)
+
+  return mod.exports
+}
 
 function getInstalledVuetifyVersion () {
   try {

--- a/tests/lib/rules/no-deprecated-classes.js
+++ b/tests/lib/rules/no-deprecated-classes.js
@@ -15,6 +15,18 @@ tester.run('no-deprecated-classes', rule, {
     '<template><div class="multiple classes" /></template>',
     '<template><div class="justify-center" /></template>',
     '<template><v-layout text-center /></template>',
+    '<template><div class="text-h1" /></template>',
+    '<template><div class="text-h2" /></template>',
+    '<template><div class="text-h3" /></template>',
+    '<template><div class="text-h4" /></template>',
+    '<template><div class="text-h5" /></template>',
+    '<template><div class="text-h6" /></template>',
+    '<template><div class="text-subtitle-1" /></template>',
+    '<template><div class="text-subtitle-2" /></template>',
+    '<template><div class="text-body-1" /></template>',
+    '<template><div class="text-body-2" /></template>',
+    '<template><div class="text-caption" /></template>',
+    '<template><div class="text-text-overline" /></template>',
     // https://github.com/vuetifyjs/eslint-plugin-vuetify/issues/2
     '<template><div class /></template>'
   ],
@@ -53,6 +65,66 @@ tester.run('no-deprecated-classes', rule, {
       code: '<template><v-layout :row="foo" wrap /></template>',
       output: '<template><v-layout :row="foo" wrap /></template>',
       errors: [`Don't use "row" on <v-layout>, see https://github.com/vuetifyjs/vuetify/commit/3f435b5a`]
+    },
+    {
+      code: '<template><div class="display-4" /></template>',
+      output: '<template><div class="text-h1" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="display-3" /></template>',
+      output: '<template><div class="text-h2" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="display-2" /></template>',
+      output: '<template><div class="text-h3" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="display-1" /></template>',
+      output: '<template><div class="text-h4" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="headline" /></template>',
+      output: '<template><div class="text-h5" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="title" /></template>',
+      output: '<template><div class="text-h6" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="subtitle-1" /></template>',
+      output: '<template><div class="text-subtitle-1" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="subtitle-2" /></template>',
+      output: '<template><div class="text-subtitle-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="body-1" /></template>',
+      output: '<template><div class="text-body-1" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="body-2" /></template>',
+      output: '<template><div class="text-body-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="caption" /></template>',
+      output: '<template><div class="text-caption" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
+    },
+    {
+      code: '<template><div class="overline" /></template>',
+      output: '<template><div class="text-overline" /></template>',
+      errors: [{ messageId: 'replacedWith' }]
     }
   ]
 })

--- a/tests/lib/rules/no-deprecated-classes.js
+++ b/tests/lib/rules/no-deprecated-classes.js
@@ -16,17 +16,6 @@ tester.run('no-deprecated-classes', rule, {
     '<template><div class="justify-center" /></template>',
     '<template><v-layout text-center /></template>',
     '<template><div class="text-h1" /></template>',
-    '<template><div class="text-h2" /></template>',
-    '<template><div class="text-h3" /></template>',
-    '<template><div class="text-h4" /></template>',
-    '<template><div class="text-h5" /></template>',
-    '<template><div class="text-h6" /></template>',
-    '<template><div class="text-subtitle-1" /></template>',
-    '<template><div class="text-subtitle-2" /></template>',
-    '<template><div class="text-body-1" /></template>',
-    '<template><div class="text-body-2" /></template>',
-    '<template><div class="text-caption" /></template>',
-    '<template><div class="text-text-overline" /></template>',
     // https://github.com/vuetifyjs/eslint-plugin-vuetify/issues/2
     '<template><div class /></template>'
   ],
@@ -69,61 +58,6 @@ tester.run('no-deprecated-classes', rule, {
     {
       code: '<template><div class="display-4" /></template>',
       output: '<template><div class="text-h1" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="display-3" /></template>',
-      output: '<template><div class="text-h2" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="display-2" /></template>',
-      output: '<template><div class="text-h3" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="display-1" /></template>',
-      output: '<template><div class="text-h4" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="headline" /></template>',
-      output: '<template><div class="text-h5" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="title" /></template>',
-      output: '<template><div class="text-h6" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="subtitle-1" /></template>',
-      output: '<template><div class="text-subtitle-1" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="subtitle-2" /></template>',
-      output: '<template><div class="text-subtitle-2" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="body-1" /></template>',
-      output: '<template><div class="text-body-1" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="body-2" /></template>',
-      output: '<template><div class="text-body-2" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="caption" /></template>',
-      output: '<template><div class="text-caption" /></template>',
-      errors: [{ messageId: 'replacedWith' }]
-    },
-    {
-      code: '<template><div class="overline" /></template>',
-      output: '<template><div class="text-overline" /></template>',
       errors: [{ messageId: 'replacedWith' }]
     }
   ]


### PR DESCRIPTION
close: https://github.com/vuetifyjs/eslint-plugin-vuetify/issues/20

I added rules for v2.3.0 typography classes.