### PR TITLE
fix: main path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-vuetify",
   "version": "2.0.0-beta.2",
   "description": "An eslint plugin for Vuetify",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "author": "Kael Watts-Deuchar <kaelwd@gmail.com>",
   "license": "MIT",
   "repository": "github:vuetifyjs/eslint-plugin-vuetify",


### PR DESCRIPTION
The wrong path prevents eslint to find the plugin when it is installed via `file:../eslint-plugin-vuetify`.

Does anyone know a lint or something to validate the main path automatically in the CI?