### PR TITLE
fix: single location attribute

### DIFF
--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -600,11 +600,37 @@ module.exports = {
     messages: {
       replacedWith: `'{{ a }}' has been replaced with '{{ b }}'`,
       removed: `'{{ name }}' has been removed`,
+      combined: `multiple {{ a }} attributes have been combined`,
     },
   },
 
   create (context) {
     return context.parserServices.defineTemplateBodyVisitor({
+      VStartTag (tag) {
+        const attrGroups = {}
+        tag.attributes.forEach(attr => {
+          if (['location'].includes(attr.key.name)) {
+            (attrGroups[attr.key.name] ??= []).push(attr)
+          }
+        })
+        Object.values(attrGroups).forEach(attrGroup => {
+          const [head, ...tail] = attrGroup
+          if (!tail.length) return
+          context.report({
+            messageId: 'combined',
+            data: {
+              a: head.key.name,
+            },
+            node: head,
+            fix (fixer) {
+              return [
+                fixer.replaceText(head.value, `"${attrGroup.map(a => a.value.value).join(" ")}"`),
+                ...tail.map(a => fixer.remove(a))
+              ]
+            },
+          })
+        })
+      },
       VAttribute (attr) {
         if (
           attr.directive &&

--- a/tests/rules/no-deprecated-props.js
+++ b/tests/rules/no-deprecated-props.js
@@ -86,5 +86,10 @@ tester.run('no-deprecated-props', rule, {
       output: '<template><v-snackbar content-class="elevation-4" /></template>',
       errors: [{ messageId: 'replacedWith' }],
     },
+    {
+      code: '<template><v-menu location="bottom" location="left" /></template>',
+      output: '<template><v-menu location="bottom left"  /></template>',
+      errors: [{ messageId: 'combined' }],
+    },
   ],
 })


### PR DESCRIPTION
`<v-menu bottom left>` is currently fixed to `<v-menu location="bottom" location="left">`. It should be fixed to `<v-menu location="bottom left">`.

I tried to generate the correct fix on the first pass, but the code wasn't very clean (maintain an array of all reports during a VStartTag, detect multiple occurrences of `replace.name`, `context.report` the reports on `VStartTag:exit`). It seems a lot cleaner to combine attributes in a second pass. `--fix` will do multiple passes automatically, so it remains easy to use.