### PR TITLE
Bugfix: VAutocomplete prop `autoSelectFirst` is not deprecated

### DIFF
--- a/src/rules/no-deprecated-props.js
+++ b/src/rules/no-deprecated-props.js
@@ -290,6 +290,7 @@ const replacements = {
   },
   VAutocomplete: {
     ...select,
+    autoSelectFirst: undefined,
   },
   VCombobox: {
     ...select,


### PR DESCRIPTION
The prop `autoSelectFirst` is not deprecated on the VAutocomplete component, only on VSelect.