### PR TITLE
fix(VSlider): start/end events not deprecated

### DIFF
--- a/src/rules/no-deprecated-events.js
+++ b/src/rules/no-deprecated-events.js
@@ -117,16 +117,12 @@ const replacements = {
     ...model,
     change: false,
     'update:error': false,
-    start: false,
-    end: false,
   },
   VRating: model,
   VSlider: {
     ...model,
     change: false,
     'update:error': false,
-    start: false,
-    end: false,
   },
   VSlideGroup: {
     change: 'update:modelValue',


### PR DESCRIPTION
closes #79, #74 