### PR TITLE
feat(rules): add rename of class `subheading` to `text-subtitle-1`

### DIFF
--- a/src/rules/no-deprecated-classes.js
+++ b/src/rules/no-deprecated-classes.js
@@ -28,6 +28,7 @@ const replacements = new Map([
   ['display-1', 'text-h4'],
   ['headline', 'text-h5'],
   ['title', 'text-h6'],
+  ['subheading', 'text-subtitle-1'],
   ['subtitle-1', 'text-subtitle-1'],
   ['subtitle-2', 'text-subtitle-2'],
   ['body-1', 'text-body-1'],


### PR DESCRIPTION
Migration from vuetifyjs v1.5 to v2:
https://v2.vuetifyjs.com/en/getting-started/upgrade-guide/#typography

fixes  #99