### PR TITLE
feat: new rules for migration to TailwindCSS

### DIFF
--- a/docs/rules/no-border-prop.md
+++ b/docs/rules/no-border-prop.md
@@ -1,0 +1,27 @@
+# Disallow the border prop (no-border-prop)
+
+:wrench: This rule is fixable with `eslint --fix`
+
+When migrating to TailwindCSS, the Vuetify `border` prop should be replaced with Tailwind border utility classes.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<v-card border />
+<v-card border="t" />
+<v-card border="t sm" />
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<v-card class="border" />
+<v-card class="border-t" />
+<v-card class="border-t border-sm" />
+```
+
+### Options
+
+This rule has no configuration options.

--- a/docs/rules/no-elevation-prop.md
+++ b/docs/rules/no-elevation-prop.md
@@ -1,0 +1,29 @@
+# Disallow the elevation prop (no-elevation-prop)
+
+:wrench: This rule is fixable with `eslint --fix`
+
+The Vuetify `elevation` prop should be replaced with the equivalent `elevation-{N}` utility class.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<v-card elevation="2" />
+<v-card elevation="4" />
+<v-card :elevation="3" />
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<v-card class="elevation-2" />
+<v-card class="elevation-4" />
+<v-card class="elevation-3" />
+```
+
+Values 0–5 are auto-fixable. Dynamic or out-of-range values are reported without a fix.
+
+### Options
+
+This rule has no configuration options.

--- a/docs/rules/no-legacy-utilities.md
+++ b/docs/rules/no-legacy-utilities.md
@@ -1,0 +1,38 @@
+# Disallow Vuetify utility classes (no-legacy-utilities)
+
+:wrench: This rule is fixable with `eslint --fix`
+
+When migrating to TailwindCSS, Vuetify utility classes should be replaced with their Tailwind equivalents.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<div class="d-flex align-center justify-space-between" />
+<div class="ma-2 pa-4" />
+<div class="font-weight-bold text-truncate" />
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<div class="flex items-center justify-between" />
+<div class="m-2 p-4" />
+<div class="font-bold truncate" />
+```
+
+### Options
+
+This rule accepts an optional object mapping class names to their replacements. Set a class to `false` to disable it.
+
+```js
+// Use all default mappings
+'vuetify/no-legacy-utilities': 'error'
+
+// Override specific mappings
+'vuetify/no-legacy-utilities': ['error', {
+  'd-flex': 'my-flex',
+  'ma-2': false, // disable this mapping
+}]
+```

--- a/docs/rules/no-rounded-prop.md
+++ b/docs/rules/no-rounded-prop.md
@@ -1,0 +1,42 @@
+# Disallow the rounded prop (no-rounded-prop)
+
+:wrench: This rule is fixable with `eslint --fix`
+
+When migrating to TailwindCSS, the Vuetify `rounded` prop should be replaced with Tailwind rounded utility classes.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```html
+<v-card rounded />
+<v-card rounded="lg" />
+<v-card rounded="circle" />
+<v-card rounded="shaped" />
+```
+
+Examples of **correct** code for this rule:
+
+```html
+<v-card class="rounded" />
+<v-card class="rounded-lg" />
+<v-card class="rounded-full" />
+<v-card class="rounded-te-xl rounded-bs-xl" />
+```
+
+### Rounded to Tailwind Mapping
+
+| Rounded Value | Tailwind Class                |
+|---------------|-------------------------------|
+| (boolean)     | `rounded`                     |
+| `0`           | `rounded-none`                |
+| `sm`          | `rounded-sm`                  |
+| `lg`          | `rounded-lg`                  |
+| `xl`          | `rounded-xl`                  |
+| `circle`      | `rounded-full`                |
+| `pill`        | `rounded-full`                |
+| `shaped`      | `rounded-te-xl rounded-bs-xl` |
+
+### Options
+
+This rule has no configuration options.

--- a/src/configs/flat/tailwindcss.js
+++ b/src/configs/flat/tailwindcss.js
@@ -1,0 +1,8 @@
+module.exports = [...require('./base'), {
+  plugins: {
+    get vuetify () {
+      return require('../../index')
+    },
+  },
+  rules: require('../tailwindcss').rules,
+}]

--- a/src/configs/tailwindcss.js
+++ b/src/configs/tailwindcss.js
@@ -1,0 +1,8 @@
+module.exports = {
+  rules: {
+    'vuetify/no-elevation-prop': 'error',
+    'vuetify/no-rounded-prop': 'error',
+    'vuetify/no-border-prop': 'error',
+    'vuetify/no-legacy-utilities': 'error',
+  },
+}

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ module.exports = {
     'flat/base': require('./configs/flat/base'),
     'flat/recommended': require('./configs/flat/recommended'),
     'flat/recommended-v4': require('./configs/flat/recommended-v4'),
+
+    tailwindcss: require('./configs/tailwindcss'),
+    'flat/tailwindcss': require('./configs/flat/tailwindcss'),
   },
   rules: requireindex(path.join(__dirname, './rules')),
 }

--- a/src/rules/no-border-prop.js
+++ b/src/rules/no-border-prop.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { isVueTemplate } = require('../util/helpers');
+const { addClass, removeAttr } = require('../util/fixers');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow the `border` prop; use Tailwind border utilities instead.',
+      category: 'tailwindcss',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      replacedWith: `'border="{{ value }}"' should be replaced with class="{{ className }}"`,
+      noFix: `'border' prop should be replaced with Tailwind border utility classes`,
+    },
+  },
+  create (context) {
+    if (!isVueTemplate(context)) return {};
+
+    return context.sourceCode.parserServices.defineTemplateBodyVisitor({
+      VAttribute (attr) {
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+
+        const propName = attr.directive
+          ? attr.key.argument.rawName
+          : attr.key.rawName;
+
+        if (propName !== 'border') return;
+
+        const element = attr.parent.parent;
+        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+
+        // Boolean attribute (no value) — `border` with no `="..."`
+        if (!attr.directive && !attr.value) {
+          context.report({
+            messageId: 'replacedWith',
+            data: { value: '', className: 'border' },
+            node: propNameNode,
+            fix (fixer) {
+              return [
+                addClass(context, fixer, element, 'border'),
+                removeAttr(context, fixer, attr),
+              ];
+            },
+          });
+          return;
+        }
+
+        // Get static value
+        const value = attr.directive
+          ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
+          : attr.value?.value;
+
+        if (value != null) {
+          const className = value.split(/\s+/).filter(Boolean).map(part => `border-${part}`).join(' ');
+          context.report({
+            messageId: 'replacedWith',
+            data: { value, className },
+            node: propNameNode,
+            fix (fixer) {
+              return [
+                addClass(context, fixer, element, className),
+                removeAttr(context, fixer, attr),
+              ];
+            },
+          });
+        } else {
+          context.report({
+            messageId: 'noFix',
+            node: propNameNode,
+          });
+        }
+      },
+    });
+  },
+};

--- a/src/rules/no-border-prop.js
+++ b/src/rules/no-border-prop.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const { isVueTemplate } = require('../util/helpers');
-const { addClass, removeAttr } = require('../util/fixers');
+const { isVueTemplate } = require('../util/helpers')
+const { addClass, removeAttr } = require('../util/fixers')
 
 module.exports = {
   meta: {
@@ -17,20 +17,20 @@ module.exports = {
     },
   },
   create (context) {
-    if (!isVueTemplate(context)) return {};
+    if (!isVueTemplate(context)) return {}
 
     return context.sourceCode.parserServices.defineTemplateBodyVisitor({
       VAttribute (attr) {
-        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return
 
         const propName = attr.directive
           ? attr.key.argument.rawName
-          : attr.key.rawName;
+          : attr.key.rawName
 
-        if (propName !== 'border') return;
+        if (propName !== 'border') return
 
-        const element = attr.parent.parent;
-        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+        const element = attr.parent.parent
+        const propNameNode = attr.directive ? attr.key.argument : attr.key
 
         // Boolean attribute (no value) — `border` with no `="..."`
         if (!attr.directive && !attr.value) {
@@ -42,19 +42,19 @@ module.exports = {
               return [
                 addClass(context, fixer, element, 'border'),
                 removeAttr(context, fixer, attr),
-              ];
+              ]
             },
-          });
-          return;
+          })
+          return
         }
 
         // Get static value
         const value = attr.directive
           ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
-          : attr.value?.value;
+          : attr.value?.value
 
         if (value != null) {
-          const className = value.split(/\s+/).filter(Boolean).map(part => `border-${part}`).join(' ');
+          const className = value.split(/\s+/).filter(Boolean).map(part => `border-${part}`).join(' ')
           context.report({
             messageId: 'replacedWith',
             data: { value, className },
@@ -63,16 +63,16 @@ module.exports = {
               return [
                 addClass(context, fixer, element, className),
                 removeAttr(context, fixer, attr),
-              ];
+              ]
             },
-          });
+          })
         } else {
           context.report({
             messageId: 'noFix',
             node: propNameNode,
-          });
+          })
         }
       },
-    });
+    })
   },
-};
+}

--- a/src/rules/no-elevation-prop.js
+++ b/src/rules/no-elevation-prop.js
@@ -1,9 +1,9 @@
-'use strict';
+'use strict'
 
-const { isVueTemplate } = require('../util/helpers');
-const { addClass, removeAttr } = require('../util/fixers');
+const { isVueTemplate } = require('../util/helpers')
+const { addClass, removeAttr } = require('../util/fixers')
 
-const validElevations = new Set(['0', '1', '2', '3', '4', '5']);
+const validElevations = new Set(['0', '1', '2', '3', '4', '5'])
 
 module.exports = {
   meta: {
@@ -19,28 +19,28 @@ module.exports = {
     },
   },
   create (context) {
-    if (!isVueTemplate(context)) return {};
+    if (!isVueTemplate(context)) return {}
 
     return context.sourceCode.parserServices.defineTemplateBodyVisitor({
       VAttribute (attr) {
-        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return
 
         const propName = attr.directive
           ? attr.key.argument.rawName
-          : attr.key.rawName;
+          : attr.key.rawName
 
-        if (propName !== 'elevation') return;
+        if (propName !== 'elevation') return
 
-        const element = attr.parent.parent;
-        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+        const element = attr.parent.parent
+        const propNameNode = attr.directive ? attr.key.argument : attr.key
 
         // Get static value
         const value = attr.directive
           ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
-          : attr.value?.value;
+          : attr.value?.value
 
         if (value != null && validElevations.has(value)) {
-          const className = `elevation-${value}`;
+          const className = `elevation-${value}`
           context.report({
             messageId: 'replacedWith',
             data: { value, className },
@@ -49,16 +49,16 @@ module.exports = {
               return [
                 addClass(context, fixer, element, className),
                 removeAttr(context, fixer, attr),
-              ];
+              ]
             },
-          });
+          })
         } else {
           context.report({
             messageId: 'noFix',
             node: propNameNode,
-          });
+          })
         }
       },
-    });
+    })
   },
-};
+}

--- a/src/rules/no-elevation-prop.js
+++ b/src/rules/no-elevation-prop.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { isVueTemplate } = require('../util/helpers');
+const { addClass, removeAttr } = require('../util/fixers');
+
+const validElevations = new Set(['0', '1', '2', '3', '4', '5']);
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow the `elevation` prop; use Tailwind shadow utilities instead.',
+      category: 'tailwindcss',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      replacedWith: `'elevation="{{ value }}"' should be replaced with class="{{ className }}"`,
+      noFix: `'elevation' prop should be replaced with a Tailwind shadow utility class`,
+    },
+  },
+  create (context) {
+    if (!isVueTemplate(context)) return {};
+
+    return context.sourceCode.parserServices.defineTemplateBodyVisitor({
+      VAttribute (attr) {
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+
+        const propName = attr.directive
+          ? attr.key.argument.rawName
+          : attr.key.rawName;
+
+        if (propName !== 'elevation') return;
+
+        const element = attr.parent.parent;
+        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+
+        // Get static value
+        const value = attr.directive
+          ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
+          : attr.value?.value;
+
+        if (value != null && validElevations.has(value)) {
+          const className = `elevation-${value}`;
+          context.report({
+            messageId: 'replacedWith',
+            data: { value, className },
+            node: propNameNode,
+            fix (fixer) {
+              return [
+                addClass(context, fixer, element, className),
+                removeAttr(context, fixer, attr),
+              ];
+            },
+          });
+        } else {
+          context.report({
+            messageId: 'noFix',
+            node: propNameNode,
+          });
+        }
+      },
+    });
+  },
+};

--- a/src/rules/no-legacy-utilities.js
+++ b/src/rules/no-legacy-utilities.js
@@ -1,6 +1,6 @@
-'use strict';
+'use strict'
 
-const { isVueTemplate } = require('../util/helpers');
+const { isVueTemplate } = require('../util/helpers')
 
 const defaultReplacements = {
   'd-flex': 'flex',
@@ -33,19 +33,19 @@ const defaultReplacements = {
   'fill-height': 'h-full',
   'w-100': 'w-full',
   'h-100': 'h-full',
-};
+}
 
 // Generate spacing utility mappings only for prefixes that differ between Vuetify and Tailwind
 // ma → m, pa → p (all other prefixes like mx, mt, px, pt etc. are already identical)
 for (let i = 0; i <= 16; i++) {
-  defaultReplacements[`ma-${i}`] = `m-${i}`;
-  defaultReplacements[`pa-${i}`] = `p-${i}`;
+  defaultReplacements[`ma-${i}`] = `m-${i}`
+  defaultReplacements[`pa-${i}`] = `p-${i}`
 }
-defaultReplacements['ma-auto'] = 'm-auto';
+defaultReplacements['ma-auto'] = 'm-auto'
 
 // Negative margins: ma-n1..ma-n16 → -m-1..-m-16
 for (let i = 1; i <= 16; i++) {
-  defaultReplacements[`ma-n${i}`] = `-m-${i}`;
+  defaultReplacements[`ma-n${i}`] = `-m-${i}`
 }
 
 module.exports = {
@@ -70,44 +70,44 @@ module.exports = {
     },
   },
   create (context) {
-    if (!isVueTemplate(context)) return {};
+    if (!isVueTemplate(context)) return {}
 
-    const replacements = { ...defaultReplacements, ...(context.options[0] || {}) };
+    const replacements = { ...defaultReplacements, ...(context.options[0] || {}) }
 
     for (const key of Object.keys(replacements)) {
-      if (replacements[key] === false) delete replacements[key];
+      if (replacements[key] === false) delete replacements[key]
     }
 
     return context.sourceCode.parserServices.defineTemplateBodyVisitor({
       'VAttribute[key.name="class"]' (node) {
-        if (!node.value || !node.value.value) return;
+        if (!node.value || !node.value.value) return
 
-        const classes = node.value.value.split(/\s+/).filter(Boolean);
+        const classes = node.value.value.split(/\s+/).filter(Boolean)
 
         classes.forEach(className => {
-          const replace = replacements[className];
-          if (replace == null) return;
+          const replace = replacements[className]
+          if (replace == null) return
 
-          const idx = node.value.value.indexOf(className) + 1;
+          const idx = node.value.value.indexOf(className) + 1
           const range = [
             node.value.range[0] + idx,
             node.value.range[0] + idx + className.length,
-          ];
+          ]
           const loc = {
             start: context.sourceCode.getLocFromIndex(range[0]),
             end: context.sourceCode.getLocFromIndex(range[1]),
-          };
+          }
 
           context.report({
             loc,
             messageId: 'replacedWith',
             data: { a: className, b: replace },
             fix (fixer) {
-              return fixer.replaceTextRange(range, replace);
+              return fixer.replaceTextRange(range, replace)
             },
-          });
-        });
+          })
+        })
       },
-    });
+    })
   },
-};
+}

--- a/src/rules/no-legacy-utilities.js
+++ b/src/rules/no-legacy-utilities.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { isVueTemplate } = require('../util/helpers');
+
+const defaultReplacements = {
+  'd-flex': 'flex',
+  'd-inline-flex': 'inline-flex',
+  'd-block': 'block',
+  'd-inline-block': 'inline-block',
+  'd-inline': 'inline',
+  'd-none': 'hidden',
+  'd-grid': 'grid',
+  'align-center': 'items-center',
+  'align-start': 'items-start',
+  'align-end': 'items-end',
+  'align-baseline': 'items-baseline',
+  'align-stretch': 'items-stretch',
+  'justify-space-between': 'justify-between',
+  'justify-space-around': 'justify-around',
+  'justify-space-evenly': 'justify-evenly',
+  'flex-grow-1': 'grow',
+  'flex-grow-0': 'grow-0',
+  'flex-shrink-1': 'shrink',
+  'flex-shrink-0': 'shrink-0',
+  'flex-column': 'flex-col',
+  'font-weight-bold': 'font-bold',
+  'font-weight-medium': 'font-medium',
+  'font-weight-regular': 'font-normal',
+  'font-weight-light': 'font-light',
+  'font-weight-thin': 'font-thin',
+  'text-truncate': 'truncate',
+  'text-no-wrap': 'whitespace-nowrap',
+  'fill-height': 'h-full',
+  'w-100': 'w-full',
+  'h-100': 'h-full',
+};
+
+// Generate spacing utility mappings only for prefixes that differ between Vuetify and Tailwind
+// ma → m, pa → p (all other prefixes like mx, mt, px, pt etc. are already identical)
+for (let i = 0; i <= 16; i++) {
+  defaultReplacements[`ma-${i}`] = `m-${i}`;
+  defaultReplacements[`pa-${i}`] = `p-${i}`;
+}
+defaultReplacements['ma-auto'] = 'm-auto';
+
+// Negative margins: ma-n1..ma-n16 → -m-1..-m-16
+for (let i = 1; i <= 16; i++) {
+  defaultReplacements[`ma-n${i}`] = `-m-${i}`;
+}
+
+module.exports = {
+  defaultReplacements,
+  meta: {
+    docs: {
+      description: 'Disallow Vuetify utility classes; use Tailwind equivalents instead.',
+      category: 'tailwindcss',
+    },
+    fixable: 'code',
+    schema: [{
+      type: 'object',
+      additionalProperties: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'boolean', enum: [false] },
+        ],
+      },
+    }],
+    messages: {
+      replacedWith: `'{{ a }}' has been replaced with '{{ b }}'`,
+    },
+  },
+  create (context) {
+    if (!isVueTemplate(context)) return {};
+
+    const replacements = { ...defaultReplacements, ...(context.options[0] || {}) };
+
+    for (const key of Object.keys(replacements)) {
+      if (replacements[key] === false) delete replacements[key];
+    }
+
+    return context.sourceCode.parserServices.defineTemplateBodyVisitor({
+      'VAttribute[key.name="class"]' (node) {
+        if (!node.value || !node.value.value) return;
+
+        const classes = node.value.value.split(/\s+/).filter(Boolean);
+
+        classes.forEach(className => {
+          const replace = replacements[className];
+          if (replace == null) return;
+
+          const idx = node.value.value.indexOf(className) + 1;
+          const range = [
+            node.value.range[0] + idx,
+            node.value.range[0] + idx + className.length,
+          ];
+          const loc = {
+            start: context.sourceCode.getLocFromIndex(range[0]),
+            end: context.sourceCode.getLocFromIndex(range[1]),
+          };
+
+          context.report({
+            loc,
+            messageId: 'replacedWith',
+            data: { a: className, b: replace },
+            fix (fixer) {
+              return fixer.replaceTextRange(range, replace);
+            },
+          });
+        });
+      },
+    });
+  },
+};

--- a/src/rules/no-rounded-prop.js
+++ b/src/rules/no-rounded-prop.js
@@ -1,18 +1,18 @@
-'use strict';
+'use strict'
 
-const { isVueTemplate } = require('../util/helpers');
-const { addClass, removeAttr } = require('../util/fixers');
+const { isVueTemplate } = require('../util/helpers')
+const { addClass, removeAttr } = require('../util/fixers')
 
 const roundedMap = {
   '': 'rounded',
-  '0': 'rounded-none',
-  'sm': 'rounded-sm',
-  'lg': 'rounded-lg',
-  'xl': 'rounded-xl',
-  'circle': 'rounded-full',
-  'pill': 'rounded-full',
-  'shaped': 'rounded-te-xl rounded-bs-xl',
-};
+  0: 'rounded-none',
+  sm: 'rounded-sm',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  circle: 'rounded-full',
+  pill: 'rounded-full',
+  shaped: 'rounded-te-xl rounded-bs-xl',
+}
 
 module.exports = {
   meta: {
@@ -28,24 +28,24 @@ module.exports = {
     },
   },
   create (context) {
-    if (!isVueTemplate(context)) return {};
+    if (!isVueTemplate(context)) return {}
 
     return context.sourceCode.parserServices.defineTemplateBodyVisitor({
       VAttribute (attr) {
-        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return
 
         const propName = attr.directive
           ? attr.key.argument.rawName
-          : attr.key.rawName;
+          : attr.key.rawName
 
-        if (propName !== 'rounded') return;
+        if (propName !== 'rounded') return
 
-        const element = attr.parent.parent;
-        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+        const element = attr.parent.parent
+        const propNameNode = attr.directive ? attr.key.argument : attr.key
 
         // Boolean attribute (no value) — `rounded` with no `="..."`
         if (!attr.directive && !attr.value) {
-          const className = roundedMap[''];
+          const className = roundedMap['']
           context.report({
             messageId: 'replacedWith',
             data: { valueDisplay: '', className },
@@ -54,19 +54,19 @@ module.exports = {
               return [
                 addClass(context, fixer, element, className),
                 removeAttr(context, fixer, attr),
-              ];
+              ]
             },
-          });
-          return;
+          })
+          return
         }
 
         // Get static value
         const value = attr.directive
           ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
-          : attr.value?.value;
+          : attr.value?.value
 
         if (value != null && roundedMap[value] != null) {
-          const className = roundedMap[value];
+          const className = roundedMap[value]
           context.report({
             messageId: 'replacedWith',
             data: { valueDisplay: `="${value}"`, className },
@@ -75,16 +75,16 @@ module.exports = {
               return [
                 addClass(context, fixer, element, className),
                 removeAttr(context, fixer, attr),
-              ];
+              ]
             },
-          });
+          })
         } else {
           context.report({
             messageId: 'noFix',
             node: propNameNode,
-          });
+          })
         }
       },
-    });
+    })
   },
-};
+}

--- a/src/rules/no-rounded-prop.js
+++ b/src/rules/no-rounded-prop.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { isVueTemplate } = require('../util/helpers');
+const { addClass, removeAttr } = require('../util/fixers');
+
+const roundedMap = {
+  '': 'rounded',
+  '0': 'rounded-none',
+  'sm': 'rounded-sm',
+  'lg': 'rounded-lg',
+  'xl': 'rounded-xl',
+  'circle': 'rounded-full',
+  'pill': 'rounded-full',
+  'shaped': 'rounded-te-xl rounded-bs-xl',
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow the `rounded` prop; use Tailwind rounded utilities instead.',
+      category: 'tailwindcss',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      replacedWith: `'rounded{{ valueDisplay }}' should be replaced with class="{{ className }}"`,
+      noFix: `'rounded' prop should be replaced with a Tailwind rounded utility class`,
+    },
+  },
+  create (context) {
+    if (!isVueTemplate(context)) return {};
+
+    return context.sourceCode.parserServices.defineTemplateBodyVisitor({
+      VAttribute (attr) {
+        if (attr.directive && (attr.key.name.name !== 'bind' || !attr.key.argument)) return;
+
+        const propName = attr.directive
+          ? attr.key.argument.rawName
+          : attr.key.rawName;
+
+        if (propName !== 'rounded') return;
+
+        const element = attr.parent.parent;
+        const propNameNode = attr.directive ? attr.key.argument : attr.key;
+
+        // Boolean attribute (no value) — `rounded` with no `="..."`
+        if (!attr.directive && !attr.value) {
+          const className = roundedMap[''];
+          context.report({
+            messageId: 'replacedWith',
+            data: { valueDisplay: '', className },
+            node: propNameNode,
+            fix (fixer) {
+              return [
+                addClass(context, fixer, element, className),
+                removeAttr(context, fixer, attr),
+              ];
+            },
+          });
+          return;
+        }
+
+        // Get static value
+        const value = attr.directive
+          ? (attr.value?.expression?.type === 'Literal' ? String(attr.value.expression.value) : null)
+          : attr.value?.value;
+
+        if (value != null && roundedMap[value] != null) {
+          const className = roundedMap[value];
+          context.report({
+            messageId: 'replacedWith',
+            data: { valueDisplay: `="${value}"`, className },
+            node: propNameNode,
+            fix (fixer) {
+              return [
+                addClass(context, fixer, element, className),
+                removeAttr(context, fixer, attr),
+              ];
+            },
+          });
+        } else {
+          context.report({
+            messageId: 'noFix',
+            node: propNameNode,
+          });
+        }
+      },
+    });
+  },
+};

--- a/tests/rules/no-border-prop.js
+++ b/tests/rules/no-border-prop.js
@@ -1,0 +1,54 @@
+const { tester } = require('../setup')
+const rule = require('../../src/rules/no-border-prop')
+
+tester.run('no-border-prop', rule, {
+  valid: [
+    '<template><v-card class="border-t" /></template>',
+    '<template><v-card /></template>',
+    '<template><div class="border" /></template>',
+  ],
+  invalid: [
+    // Boolean (no value) — border as prop
+    {
+      code: '<template><v-card border /></template>',
+      output: '<template><v-card class="border" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Single value
+    {
+      code: '<template><v-card border="t" /></template>',
+      output: '<template><v-card class="border-t" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Multiple values
+    {
+      code: '<template><v-card border="t sm" /></template>',
+      output: '<template><v-card class="border-t border-sm" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Append to existing class
+    {
+      code: '<template><v-card border="t" class="my-card" /></template>',
+      output: '<template><v-card class="my-card border-t" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Bound static value
+    {
+      code: '<template><v-card :border="\'b\'" /></template>',
+      output: '<template><v-card class="border-b" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Complex value
+    {
+      code: '<template><v-card border="t b opacity-50" /></template>',
+      output: '<template><v-card class="border-t border-b border-opacity-50" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Dynamic value — no fix
+    {
+      code: '<template><v-card :border="borderValue" /></template>',
+      output: null,
+      errors: [{ messageId: 'noFix' }],
+    },
+  ],
+})

--- a/tests/rules/no-elevation-prop.js
+++ b/tests/rules/no-elevation-prop.js
@@ -1,0 +1,67 @@
+const { tester } = require('../setup')
+const rule = require('../../src/rules/no-elevation-prop')
+
+tester.run('no-elevation-prop', rule, {
+  valid: [
+    '<template><v-card class="elevation-2" /></template>',
+    '<template><v-card /></template>',
+    '<template><div class="elevation-4" /></template>',
+  ],
+  invalid: [
+    // Static elevation values 0-5
+    {
+      code: '<template><v-card elevation="0" /></template>',
+      output: '<template><v-card class="elevation-0" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><v-card elevation="1" /></template>',
+      output: '<template><v-card class="elevation-1" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><v-card elevation="2" /></template>',
+      output: '<template><v-card class="elevation-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><v-card elevation="3" /></template>',
+      output: '<template><v-card class="elevation-3" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><v-card elevation="4" /></template>',
+      output: '<template><v-card class="elevation-4" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><v-card elevation="5" /></template>',
+      output: '<template><v-card class="elevation-5" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Append to existing class
+    {
+      code: '<template><v-card elevation="2" class="my-card" /></template>',
+      output: '<template><v-card class="my-card elevation-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Bound static value
+    {
+      code: '<template><v-card :elevation="3" /></template>',
+      output: '<template><v-card class="elevation-3" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Out of range — no fix
+    {
+      code: '<template><v-card elevation="10" /></template>',
+      output: null,
+      errors: [{ messageId: 'noFix' }],
+    },
+    // Dynamic value — no fix
+    {
+      code: '<template><v-card :elevation="level" /></template>',
+      output: null,
+      errors: [{ messageId: 'noFix' }],
+    },
+  ],
+})

--- a/tests/rules/no-legacy-utilities.js
+++ b/tests/rules/no-legacy-utilities.js
@@ -1,0 +1,154 @@
+const { tester } = require('../setup')
+const rule = require('../../src/rules/no-legacy-utilities')
+
+tester.run('no-legacy-utilities', rule, {
+  valid: [
+    // Tailwind classes are fine
+    '<template><div class="flex" /></template>',
+    '<template><div class="hidden" /></template>',
+    '<template><div class="items-center" /></template>',
+    // Unrelated classes
+    '<template><div class="my-custom-class" /></template>',
+    // Empty
+    '<template><div class="" /></template>',
+    '<template><div class /></template>',
+    // Disabled via config
+    {
+      code: '<template><div class="d-flex" /></template>',
+      options: [{ 'd-flex': false }],
+    },
+  ],
+  invalid: [
+    // Display utilities
+    {
+      code: '<template><div class="d-flex" /></template>',
+      output: '<template><div class="flex" /></template>',
+      errors: [{ messageId: 'replacedWith', data: { a: 'd-flex', b: 'flex' } }],
+    },
+    {
+      code: '<template><div class="d-none" /></template>',
+      output: '<template><div class="hidden" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="d-block" /></template>',
+      output: '<template><div class="block" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="d-inline-flex" /></template>',
+      output: '<template><div class="inline-flex" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Alignment
+    {
+      code: '<template><div class="align-center" /></template>',
+      output: '<template><div class="items-center" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="align-start" /></template>',
+      output: '<template><div class="items-start" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Justify
+    {
+      code: '<template><div class="justify-space-between" /></template>',
+      output: '<template><div class="justify-between" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="justify-space-around" /></template>',
+      output: '<template><div class="justify-around" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Flex utilities
+    {
+      code: '<template><div class="flex-grow-1" /></template>',
+      output: '<template><div class="grow" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="flex-shrink-0" /></template>',
+      output: '<template><div class="shrink-0" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="flex-column" /></template>',
+      output: '<template><div class="flex-col" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Font weight
+    {
+      code: '<template><div class="font-weight-bold" /></template>',
+      output: '<template><div class="font-bold" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="font-weight-regular" /></template>',
+      output: '<template><div class="font-normal" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Text utilities
+    {
+      code: '<template><div class="text-truncate" /></template>',
+      output: '<template><div class="truncate" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="text-no-wrap" /></template>',
+      output: '<template><div class="whitespace-nowrap" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Size utilities
+    {
+      code: '<template><div class="fill-height" /></template>',
+      output: '<template><div class="h-full" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="w-100" /></template>',
+      output: '<template><div class="w-full" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Spacing utilities
+    {
+      code: '<template><div class="ma-2" /></template>',
+      output: '<template><div class="m-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="pa-4" /></template>',
+      output: '<template><div class="p-4" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    {
+      code: '<template><div class="ma-auto" /></template>',
+      output: '<template><div class="m-auto" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Negative margins
+    {
+      code: '<template><div class="ma-n2" /></template>',
+      output: '<template><div class="-m-2" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Mixed with other classes
+    {
+      code: '<template><div class="pa-2 d-flex align-center" /></template>',
+      output: '<template><div class="p-2 flex items-center" /></template>',
+      errors: [
+        { messageId: 'replacedWith' },
+        { messageId: 'replacedWith' },
+        { messageId: 'replacedWith' },
+      ],
+    },
+    // Custom mapping override
+    {
+      code: '<template><div class="d-flex" /></template>',
+      output: '<template><div class="my-flex" /></template>',
+      options: [{ 'd-flex': 'my-flex' }],
+      errors: [{ messageId: 'replacedWith', data: { a: 'd-flex', b: 'my-flex' } }],
+    },
+  ],
+})

--- a/tests/rules/no-rounded-prop.js
+++ b/tests/rules/no-rounded-prop.js
@@ -1,0 +1,84 @@
+const { tester } = require('../setup')
+const rule = require('../../src/rules/no-rounded-prop')
+
+tester.run('no-rounded-prop', rule, {
+  valid: [
+    '<template><v-card class="rounded-lg" /></template>',
+    '<template><v-card /></template>',
+    '<template><div class="rounded-full" /></template>',
+  ],
+  invalid: [
+    // Boolean (no value)
+    {
+      code: '<template><v-card rounded /></template>',
+      output: '<template><v-card class="rounded" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="0"
+    {
+      code: '<template><v-card rounded="0" /></template>',
+      output: '<template><v-card class="rounded-none" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="sm"
+    {
+      code: '<template><v-card rounded="sm" /></template>',
+      output: '<template><v-card class="rounded-sm" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="lg"
+    {
+      code: '<template><v-card rounded="lg" /></template>',
+      output: '<template><v-card class="rounded-lg" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="xl"
+    {
+      code: '<template><v-card rounded="xl" /></template>',
+      output: '<template><v-card class="rounded-xl" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="circle"
+    {
+      code: '<template><v-card rounded="circle" /></template>',
+      output: '<template><v-card class="rounded-full" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="pill"
+    {
+      code: '<template><v-card rounded="pill" /></template>',
+      output: '<template><v-card class="rounded-full" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // rounded="shaped"
+    {
+      code: '<template><v-card rounded="shaped" /></template>',
+      output: '<template><v-card class="rounded-te-xl rounded-bs-xl" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Append to existing class
+    {
+      code: '<template><v-card rounded="lg" class="my-card" /></template>',
+      output: '<template><v-card class="my-card rounded-lg" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Bound static value
+    {
+      code: '<template><v-card :rounded="\'circle\'" /></template>',
+      output: '<template><v-card class="rounded-full" /></template>',
+      errors: [{ messageId: 'replacedWith' }],
+    },
+    // Unknown value — no fix
+    {
+      code: '<template><v-card rounded="xxl" /></template>',
+      output: null,
+      errors: [{ messageId: 'noFix' }],
+    },
+    // Dynamic value — no fix
+    {
+      code: '<template><v-card :rounded="roundedValue" /></template>',
+      output: null,
+      errors: [{ messageId: 'noFix' }],
+    },
+  ],
+})


### PR DESCRIPTION
4 new rules - useful when adopting TailwindCSS and/or UnoCSS

For every UnoCSS-based project with all `$utilities` disabled:
- `no-elevation-prop`
- `no-rounded-prop`
- `no-border-prop`

For migration to pure TailwindCSS or UnoCSS with Wind4 preset
- `no-legacy-utilities`